### PR TITLE
Fix #5

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,4 @@
+linters:
+  disable:
+    # no, we won't check every invocation of (io.Writer).Write()
+    - errcheck

--- a/cmd/gmnhg/main.go
+++ b/cmd/gmnhg/main.go
@@ -80,9 +80,9 @@ import (
 )
 
 const (
-	defaultTemplate = "single"
-	indexMdFilename = "_index.gmi.md"
-	indexFilename   = "index.gmi"
+	defaultPageTemplate = "single"
+	indexMdFilename     = "_index.gmi.md"
+	indexFilename       = "index.gmi"
 )
 
 const (
@@ -94,7 +94,6 @@ const (
 
 var (
 	tmplNameRegex     = regexp.MustCompile(templateBase + `([\w-_ /]+)\.gotmpl`)
-	contentNameRegex  = regexp.MustCompile(contentBase + `([\w-_ ]+)\.md`)
 	topLevelPostRegex = regexp.MustCompile(contentBase + `([\w-_ ]+)/([\w-_ ]+)\.md`)
 )
 
@@ -201,7 +200,7 @@ func main() {
 	}
 
 	// render posts to Gemtext and collect top level posts data
-	posts := make(map[string]*post, 0)
+	posts := make(map[string]*post)
 	topLevelPosts := make(map[string][]*post)
 	if err := filepath.Walk(contentBase, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -252,7 +251,7 @@ func main() {
 	}
 
 	var singleTemplate = defaultSingleTemplate
-	if tmpl, hasTmpl := templates["single"]; hasTmpl {
+	if tmpl, hasTmpl := templates[defaultPageTemplate]; hasTmpl {
 		singleTemplate = tmpl
 	}
 


### PR DESCRIPTION
While renderer previously assumed there would always be a single paragraph inside the blockquote, there sometimes can be either more or none.

Test case:

```md
> Testing text.
> Another line of testing text.

> This would get eaten by the renderer.

Test of a blank quote.

>
```