### PR TITLE
Add support for "alt" text for code blocks and print delimiters around elements

### DIFF
--- a/internal/gemini/renderer.go
+++ b/internal/gemini/renderer.go
@@ -37,7 +37,7 @@ var (
 	quotePrefix        = []byte("> ")
 	itemPrefix         = []byte("* ")
 	itemIndent         = []byte{'\t'}
-	preformattedToggle = []byte("```\n")
+	preformattedToggle = []byte("```")
 )
 
 var meaningfulCharsRegex = regexp.MustCompile(`\A[\s]+\z`)
@@ -206,8 +206,13 @@ func (r Renderer) paragraph(w io.Writer, node *ast.Paragraph, entering bool) (no
 
 func (r Renderer) code(w io.Writer, node *ast.CodeBlock) {
 	w.Write(preformattedToggle)
+	if node.IsFenced {
+		w.Write(node.Info)
+	}
+	w.Write(lineBreak)
 	w.Write(node.Literal)
 	w.Write(preformattedToggle)
+	w.Write(lineBreak)
 }
 
 func (r Renderer) list(w io.Writer, node *ast.List, level int) {
@@ -325,6 +330,7 @@ func (r Renderer) tableBody(t *tablewriter.Table, node *ast.TableBody) {
 func (r Renderer) table(w io.Writer, node *ast.Table, entering bool) {
 	if entering {
 		w.Write(preformattedToggle)
+		w.Write(lineBreak)
 		// gomarkdown appears to only parse headings consisting of a
 		// single line and always have a TableBody preceded by a single
 		// TableHeader but we're better off not relying on it
@@ -343,6 +349,7 @@ func (r Renderer) table(w io.Writer, node *ast.Table, entering bool) {
 		t.Render()
 	} else {
 		w.Write(preformattedToggle)
+		w.Write(lineBreak)
 	}
 }
 


### PR DESCRIPTION
## Alt text

From the Gemtext spec: "Anything which comes after the ``` characters of a line which toggles preformatted line *on* (i.e. the first, third, fifth, etc. toggling lines in a document) may be treated as "alt text" for the preformatted content. In general you should not count on this content being visible to the user but, for example, search engines may index it and screen readers may read it to users to help the user decide whether the preformatted content should be read aloud (which e.g. ASCII art generally should not be, but which source code perhaps should be). There are currently no established conventions on how alt text should be formatted."

It's common in Markdown code blocks to do something like this:
~~~
```html
<p>Test</p>
```
~~~

Hugo uses this information to choose how the code should be formatted. I'm not aware of any Gemini clients who can (yet) interpret this information usefully, but per the spec quoted above, it is allowed. I expect at least some clients to eventually support code formatting, as it's super useful.

## Printing delimiters

Currently all delimiters around code, em, strong, and del elements are stripped out. Especially with code and del, this information is semantically important. Here's an example sentence that just doesn't look right when translated by gmnhg:

Converted by gmnhg:
If you want to print the content of all .txt files, you can use find -name "*.txt" | xargs cat to pipe all .txt files through xargs into cat.

Patched version:
If you want to print the content of all .txt files, you can use \`find -name "*.txt" | xargs cat\` to pipe all .txt files through xargs into cat.

With the loss of the backtick delimiters, this sentence is really confusing. I've seen Gemini sites use backticks as if it were straight Markdown; of course the clients don't do anything special with it, but it doesn't seem to hurt the readability. Same with emphasis/strong text and asterisks. I don't love the solution for strikethrough, but it's better than nothing; semantically, losing a strikethrough could completely invert the meaning of a sentence! (Perhaps a visually better solution would be to use Unicode special characters to add a strikethrough, but I'm not sure about the implications of that across fonts and languages.)

In the future, it might make sense to allow for a command-line option or configuration file that can override this behavior.