### PR TITLE
Implement footnotes support

### DIFF
--- a/render.go
+++ b/render.go
@@ -101,7 +101,9 @@ func RenderMarkdown(md []byte, settings Settings) (geminiText []byte, metadata H
 	}
 	md = md[blockEnd+len(yamlDelimiter)*2:]
 parse:
-	ast := markdown.Parse(md, parser.NewWithExtensions(parser.CommonExtensions|parser.NoEmptyLineBeforeBlock))
+	ast := markdown.Parse(md, parser.NewWithExtensions(parser.CommonExtensions|
+		parser.NoEmptyLineBeforeBlock|
+		parser.Footnotes))
 	var content []byte
 	if settings.Has(WithMetadata) && metadata.PostTitle != "" {
 		content = markdown.Render(ast, gemini.NewRendererWithMetadata(metadata))


### PR DESCRIPTION
This adds initial foonotes support, with rendering those as a list in the document end (which is how gomarkdown represents footnotes). The footnotes themselves aren't yet displayed in the document text.

Fixes #16.