### PR TITLE
Add test boilerplate and tests for horizontal rule

### DIFF
--- a/internal/gemini/renderer_test.go
+++ b/internal/gemini/renderer_test.go
@@ -28,7 +28,7 @@ func testRenderNodeStep(node ast.Node, entering bool, expectedGemini []byte, exp
 		if walkStatus != expectedWalkStatus {
 			t.Error(fmt.Sprintf("Walk status %T does not match expected value %T!", walkStatus, expectedWalkStatus))
 		}
-		if bytes.Compare(w.Bytes(), expectedGemini) != 0 {
+		if !bytes.Equal(w.Bytes(), expectedGemini) {
 			t.Error(fmt.Sprintf("Output does not match expected!\n\nActual output:\n\n%s\n%s\n%s\n\nExpected output:\n\n%s\n%s\n%s", divider, w.Bytes(), divider, divider, expectedGemini, divider))
 		}
 	}

--- a/internal/gemini/renderer_test.go
+++ b/internal/gemini/renderer_test.go
@@ -1,0 +1,34 @@
+package gemini
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+	
+	gemini "github.com/tdemin/gmnhg"
+)
+
+var (
+	divider = "============================================================"
+)
+
+func TestHr(t *testing.T) {
+	t.Run("Dash",testRenderer([]byte("---"), []byte("---\n")))
+	t.Run("Asterisk",testRenderer([]byte("***"), []byte("---\n")))
+	t.Run("Underscore",testRenderer([]byte("___"), []byte("---\n")))
+	t.Run("Inline",testRenderer([]byte("Test ---"), []byte("Test ---\n")))
+	t.Run("Between paragraphs",testRenderer([]byte("Foo\n\n---\n\nBar"), []byte("Foo\n\n---\n\nBar\n")))
+	t.Run("Adjacent",testRenderer([]byte("Foo\n\n---\n\n---\n\nBar"), []byte("Foo\n\n---\n\n---\n\nBar\n")))
+}
+
+func testRenderer(markdown []byte, expectedGemini []byte) func(*testing.T) {
+	return func(t *testing.T) {
+		geminiContent, _, err := gemini.RenderMarkdown(markdown, gemini.Defaults)
+		if err != nil {
+			t.Error(fmt.Errorf("Error during rendering: %w", err))
+		}
+		if bytes.Compare(geminiContent, expectedGemini) != 0 {
+			t.Error(fmt.Sprintf("Output does not match expected!\n\nActual output:\n\n%s\n%s\n%s\n\nExpected output:\n\n%s\n%s\n%s", divider, geminiContent, divider, divider, expectedGemini, divider))
+		}
+	}
+}

--- a/internal/gemini/renderer_test.go
+++ b/internal/gemini/renderer_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"testing"
-	
+
 	gemini "github.com/tdemin/gmnhg"
 )
 
@@ -13,12 +13,12 @@ var (
 )
 
 func TestHr(t *testing.T) {
-	t.Run("Dash",testRenderer([]byte("---"), []byte("---\n")))
-	t.Run("Asterisk",testRenderer([]byte("***"), []byte("---\n")))
-	t.Run("Underscore",testRenderer([]byte("___"), []byte("---\n")))
-	t.Run("Inline",testRenderer([]byte("Test ---"), []byte("Test ---\n")))
-	t.Run("Between paragraphs",testRenderer([]byte("Foo\n\n---\n\nBar"), []byte("Foo\n\n---\n\nBar\n")))
-	t.Run("Adjacent",testRenderer([]byte("Foo\n\n---\n\n---\n\nBar"), []byte("Foo\n\n---\n\n---\n\nBar\n")))
+	t.Run("Dash", testRenderer([]byte("---"), []byte("---\n")))
+	t.Run("Asterisk", testRenderer([]byte("***"), []byte("---\n")))
+	t.Run("Underscore", testRenderer([]byte("___"), []byte("---\n")))
+	t.Run("Inline", testRenderer([]byte("Test ---"), []byte("Test ---\n")))
+	t.Run("Between paragraphs", testRenderer([]byte("Foo\n\n---\n\nBar"), []byte("Foo\n\n---\n\nBar\n")))
+	t.Run("Adjacent", testRenderer([]byte("Foo\n\n---\n\n---\n\nBar"), []byte("Foo\n\n---\n\n---\n\nBar\n")))
 }
 
 func testRenderer(markdown []byte, expectedGemini []byte) func(*testing.T) {

--- a/render_test.go
+++ b/render_test.go
@@ -27,7 +27,7 @@ func testRenderer(markdown []byte, expectedGemini []byte) func(*testing.T) {
 		if err != nil {
 			t.Error(fmt.Errorf("Error during rendering: %w", err))
 		}
-		if bytes.Compare(geminiContent, expectedGemini) != 0 {
+		if !bytes.Equal(geminiContent, expectedGemini) {
 			t.Error(fmt.Sprintf("Output does not match expected!\n\nActual output:\n\n%s\n%s\n%s\n\nExpected output:\n\n%s\n%s\n%s", divider, geminiContent, divider, divider, expectedGemini, divider))
 		}
 	}

--- a/render_test.go
+++ b/render_test.go
@@ -1,0 +1,34 @@
+package gemini_test
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	. "github.com/tdemin/gmnhg"
+)
+
+var (
+	divider = "============================================================"
+)
+
+func TestHr(t *testing.T) {
+	t.Run("Dash", testRenderer([]byte("---"), []byte("---\n")))
+	t.Run("Asterisk", testRenderer([]byte("***"), []byte("---\n")))
+	t.Run("Underscore", testRenderer([]byte("___"), []byte("---\n")))
+	t.Run("Inline", testRenderer([]byte("Test ---"), []byte("Test ---\n")))
+	t.Run("Between paragraphs", testRenderer([]byte("Foo\n\n---\n\nBar"), []byte("Foo\n\n---\n\nBar\n")))
+	t.Run("Adjacent", testRenderer([]byte("Foo\n\n---\n\n---\n\nBar"), []byte("Foo\n\n---\n\n---\n\nBar\n")))
+}
+
+func testRenderer(markdown []byte, expectedGemini []byte) func(*testing.T) {
+	return func(t *testing.T) {
+		geminiContent, _, err := RenderMarkdown(markdown, Defaults)
+		if err != nil {
+			t.Error(fmt.Errorf("Error during rendering: %w", err))
+		}
+		if bytes.Compare(geminiContent, expectedGemini) != 0 {
+			t.Error(fmt.Sprintf("Output does not match expected!\n\nActual output:\n\n%s\n%s\n%s\n\nExpected output:\n\n%s\n%s\n%s", divider, geminiContent, divider, divider, expectedGemini, divider))
+		}
+	}
+}


### PR DESCRIPTION
To get a start on #13.

I separated the integration tests for the main `render.go` from the unit tests for `internal/gemini/renderer.go`. Dropped in some basic example tests for horizontal rule as a simple starting point.

If you know of a better way to output actual vs expected rendered text for failing tests, let me know. I bordered each with a divider so it would be easier to see the missing newlines. Maybe there's some kind of diff library we could use to make the differences easier to spot, but this seems to work ok.