### PR TITLE
Implement a generic links extractor

### DIFF
--- a/internal/gemini/renderer.go
+++ b/internal/gemini/renderer.go
@@ -255,18 +255,16 @@ func (r Renderer) linksList(w io.Writer, links []ast.Node) {
 }
 
 func isLinksOnlyParagraph(node *ast.Paragraph) bool {
-	if node := node.AsContainer(); node != nil {
-		for _, child := range node.Children {
-			switch child := child.(type) {
-			case *ast.Text:
-				if emptyLineRegex.Find(child.Literal) != nil {
-					continue
-				}
-			case *ast.Link, *ast.Image:
+	for _, child := range node.Children {
+		switch child := child.(type) {
+		case *ast.Text:
+			if emptyLineRegex.Find(child.Literal) != nil {
 				continue
 			}
-			return false
+		case *ast.Link, *ast.Image:
+			continue
 		}
+		return false
 	}
 	return true
 }

--- a/internal/gemini/renderer.go
+++ b/internal/gemini/renderer.go
@@ -179,9 +179,7 @@ func (r Renderer) heading(w io.Writer, node *ast.Heading, entering bool) {
 			heading[gemtextHeadingLevelLimit] = ' '
 		}
 		w.Write(heading)
-		for _, text := range node.Children {
-			w.Write(text.AsLeaf().Literal)
-		}
+		r.text(w, node)
 	} else {
 		w.Write(lineBreak)
 	}

--- a/internal/gemini/renderer.go
+++ b/internal/gemini/renderer.go
@@ -368,7 +368,12 @@ func (r Renderer) text(w io.Writer, node ast.Node) {
 	if node := node.AsContainer(); node != nil {
 		w.Write(delimiter)
 		for _, child := range node.Children {
-			r.text(w, child)
+			// skip non-text child elements from rendering
+			switch child := child.(type) {
+			case *ast.List:
+			default:
+				r.text(w, child)
+			}
 		}
 		w.Write(delimiter)
 	}

--- a/internal/gemini/renderer.go
+++ b/internal/gemini/renderer.go
@@ -186,7 +186,7 @@ func (r Renderer) heading(w io.Writer, node *ast.Heading, entering bool) {
 	}
 }
 
-func extractLinks(node ast.Node) (stack []interface{}) {
+func extractLinks(node ast.Node) (stack []ast.Node) {
 	if node := node.AsContainer(); node != nil {
 		for _, subnode := range node.Children {
 			stack = append(stack, extractLinks(subnode)...)
@@ -207,7 +207,7 @@ func extractLinks(node ast.Node) (stack []interface{}) {
 	return stack
 }
 
-func (r Renderer) linksList(w io.Writer, links []interface{}) {
+func (r Renderer) linksList(w io.Writer, links []ast.Node) {
 	for _, link := range links {
 		switch link := link.(type) {
 		case *ast.Link:


### PR DESCRIPTION
Before this, links would only be scraped from paragraphs and rendered as a block after parent paragraph. This replaces this logic with a generic links extractor that would recursively collect every link from any parent node, including footnotes, blockquotes, and lists.

Fixes #17 and #23.