### PR TITLE
Add RSS support for #26

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ Usage of md2gmn:
 md2gmn is mainly made to facilitate testing the Gemtext renderer but
 can be used as a standalone program as well.
 
+## Site configuration
+
+For RSS feeds to use correct URLs, you should define geminiBaseURL in
+Hugo's configuration file (config.toml, config.yaml, or config.json).
+
+Other attributes from this file, such as site title, will also be used
+during RSS feed generation if they are defined.
+
 ## License
 
 This program is redistributed under the terms and conditions of the GNU

--- a/cmd/gmnhg/main.go
+++ b/cmd/gmnhg/main.go
@@ -325,7 +325,7 @@ func main() {
 			dirs := strings.Split(matches[1], "/")
 			// only include leaf resources pages in leaf index
 			if !isLeafIndex && hasSubPath(leafIndexPaths, path) {
-				topLevelPosts["/" + matches[1]] = append(topLevelPosts["/" + matches[1]], p)
+				topLevelPosts["/"+matches[1]] = append(topLevelPosts["/"+matches[1]], p)
 			} else {
 				// include normal pages in all subdirectory indices
 				for i, dir := range dirs {
@@ -334,7 +334,7 @@ func main() {
 					}
 				}
 				for _, dir := range dirs {
-					topLevelPosts["/" + dir] = append(topLevelPosts["/" + dir], p)
+					topLevelPosts["/"+dir] = append(topLevelPosts["/"+dir], p)
 				}
 				topLevelPosts["/"] = append(topLevelPosts["/"], p)
 			}
@@ -442,7 +442,7 @@ func main() {
 	// render RSS/Atom feeds
 	for dirname, posts := range topLevelPosts {
 		// do not render RSS for leaf paths
-		if hasSubPath(leafIndexPaths, path.Join(contentBase, dirname) + "/") {
+		if hasSubPath(leafIndexPaths, path.Join(contentBase, dirname)+"/") {
 			continue
 		}
 		tmpl, hasTmpl := templates["top"+dirname+".rss"]

--- a/cmd/gmnhg/main.go
+++ b/cmd/gmnhg/main.go
@@ -440,6 +440,9 @@ func main() {
 	}
 
 	// render RSS/Atom feeds
+	if tmpl, hasTmpl := templates["_default/rss"]; hasTmpl {
+		defaultRssTemplate = tmpl
+	}
 	for dirname, posts := range topLevelPosts {
 		// do not render RSS for leaf paths
 		if hasSubPath(leafIndexPaths, path.Join(contentBase, dirname)+"/") {
@@ -447,8 +450,8 @@ func main() {
 		}
 		tmpl, hasTmpl := templates["top"+dirname+".rss"]
 		if !hasTmpl {
-			if t, hasTmpl := templates["rss"]; dirname == "/" && hasTmpl {
-				tmpl = t
+			if rootTmpl, hasTmpl := templates["rss"]; dirname == "/" && hasTmpl {
+				tmpl = rootTmpl
 			} else {
 				tmpl = defaultRssTemplate
 			}

--- a/cmd/gmnhg/main.go
+++ b/cmd/gmnhg/main.go
@@ -91,12 +91,12 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
-	"encoding/json"
 	"os"
 	"path"
 	"path/filepath"
@@ -135,7 +135,7 @@ var hugoConfigFiles = []string{"config.toml", "config.yaml", "config.json"}
 
 type SiteConfig struct {
 	GeminiBaseURL string `yaml:"geminiBaseURL"`
-	Title			    string `yaml:"title"`
+	Title         string `yaml:"title"`
 	Copyright     string `yaml:"copyright"`
 	LanguageCode  string `yaml:"languageCode"`
 }
@@ -221,18 +221,18 @@ func main() {
 				panic(err)
 			}
 			switch ext := filepath.Ext(filename); ext {
-				case ".toml":
-					if err := toml.Unmarshal(buf, &siteConf); err != nil {
-						panic(err)
-					}
-				case ".yaml":
-					if err := yaml.Unmarshal(buf, &siteConf); err != nil {
-						panic(err)
-					}
-				case ".json":
-					if err := json.Unmarshal(buf, &siteConf); err != nil {
-						panic(err)
-					}
+			case ".toml":
+				if err := toml.Unmarshal(buf, &siteConf); err != nil {
+					panic(err)
+				}
+			case ".yaml":
+				if err := yaml.Unmarshal(buf, &siteConf); err != nil {
+					panic(err)
+				}
+			case ".json":
+				if err := json.Unmarshal(buf, &siteConf); err != nil {
+					panic(err)
+				}
 			}
 			break
 		}
@@ -316,9 +316,9 @@ func main() {
 		}
 		key := strings.TrimPrefix(strings.TrimSuffix(path, ".md"), contentBase) + ".gmi"
 		p := gmnhg.Post{
-			Post:      gemText,
-			Link:      key,
-			Metadata:  metadata,
+			Post:     gemText,
+			Link:     key,
+			Metadata: metadata,
 		}
 		posts[key] = p
 		if matches := pagePathRegex.FindStringSubmatch(path); matches != nil {
@@ -455,14 +455,14 @@ func main() {
 		}
 		sc := map[string]interface{}{
 			"GeminiBaseURL": siteConf.GeminiBaseURL,
-			"Title":	       siteConf.Title,
+			"Title":         siteConf.Title,
 			"Copyright":     siteConf.Copyright,
 			"LanguageCode":  siteConf.LanguageCode,
 		}
 		cnt := map[string]interface{}{
 			"Posts":   posts,
 			"Dirname": dirname,
-			"Link":    dirname+"/"+rssFilename,
+			"Link":    dirname + "/" + rssFilename,
 			"Site":    sc,
 		}
 		buf := bytes.Buffer{}

--- a/cmd/gmnhg/main.go
+++ b/cmd/gmnhg/main.go
@@ -78,6 +78,26 @@
 // (https://github.com/Masterminds/sprig); see the sprig documentation
 // for more details.
 //
+// RSS will be generated as rss.xml for the root directory and all
+// branch directories. Site title and other RSS metadata will be
+// loaded from the Hugo configuration file (config.toml, config.yaml,
+// or config.json).
+//
+// A new setting, geminiBaseURL, should be added to the Hugo
+// configuration file to ensure that RSS paths are correct. This is
+// more or less the same as Hugo's baseURL, but is separate in case
+// your Gemini site is deployed to a different server.
+//
+// RSS templates can be overriden by defining a template in one of
+// several places:
+//
+// * Site-wide: gmnhg/_default/rss.gotmpl
+//
+// * Site root: gmnhg/rss.gotmpl
+//
+// * Directories: gmnhg/rss/dirname.gotmpl for a directory "/dirname"
+// or gmnhg/rss/dirname/subdir.gotmpl for "/dirname/subdir"
+//
 // One might want to ignore _index.gmi.md files with the following Hugo
 // config option in config.toml:
 //
@@ -448,7 +468,7 @@ func main() {
 		if hasSubPath(leafIndexPaths, path.Join(contentBase, dirname)+"/") {
 			continue
 		}
-		tmpl, hasTmpl := templates["top"+dirname+"_rss"]
+		tmpl, hasTmpl := templates["rss"+dirname]
 		if !hasTmpl {
 			if rootTmpl, hasTmpl := templates["rss"]; dirname == "/" && hasTmpl {
 				tmpl = rootTmpl

--- a/cmd/gmnhg/main.go
+++ b/cmd/gmnhg/main.go
@@ -330,11 +330,11 @@ func main() {
 				// include normal pages in all subdirectory indices
 				for i, dir := range dirs {
 					if i > 0 {
-						dirs[i] = "/" + dirs[i-1] + "/" + dir
+						dirs[i] = dirs[i-1] + "/" + dir
 					}
 				}
 				for _, dir := range dirs {
-					topLevelPosts[dir] = append(topLevelPosts[dir], p)
+					topLevelPosts["/" + dir] = append(topLevelPosts["/" + dir], p)
 				}
 				topLevelPosts["/"] = append(topLevelPosts["/"], p)
 			}

--- a/cmd/gmnhg/main.go
+++ b/cmd/gmnhg/main.go
@@ -325,18 +325,18 @@ func main() {
 			dirs := strings.Split(matches[1], "/")
 			// only include leaf resources pages in leaf index
 			if !isLeafIndex && hasSubPath(leafIndexPaths, path) {
-				topLevelPosts[matches[1]] = append(topLevelPosts[matches[1]], p)
+				topLevelPosts["/" + matches[1]] = append(topLevelPosts["/" + matches[1]], p)
 			} else {
 				// include normal pages in all subdirectory indices
 				for i, dir := range dirs {
 					if i > 0 {
-						dirs[i] = dirs[i-1] + "/" + dir
+						dirs[i] = "/" + dirs[i-1] + "/" + dir
 					}
 				}
 				for _, dir := range dirs {
 					topLevelPosts[dir] = append(topLevelPosts[dir], p)
 				}
-				topLevelPosts[""] = append(topLevelPosts[""], p)
+				topLevelPosts["/"] = append(topLevelPosts["/"], p)
 			}
 		}
 		return nil
@@ -386,10 +386,10 @@ func main() {
 	// render indexes for top-level dirs
 	for dirname, posts := range topLevelPosts {
 		// skip the main index
-		if dirname == "" {
+		if dirname == "/" {
 			continue
 		}
-		tmpl, hasTmpl := templates["top/"+dirname]
+		tmpl, hasTmpl := templates["top"+dirname]
 		if !hasTmpl {
 			continue
 		}
@@ -442,12 +442,12 @@ func main() {
 	// render RSS/Atom feeds
 	for dirname, posts := range topLevelPosts {
 		// do not render RSS for leaf paths
-		if hasSubPath(leafIndexPaths, contentBase+dirname+"/") {
+		if hasSubPath(leafIndexPaths, path.Join(contentBase, dirname) + "/") {
 			continue
 		}
-		tmpl, hasTmpl := templates["top/"+dirname+".rss"]
+		tmpl, hasTmpl := templates["top"+dirname+".rss"]
 		if !hasTmpl {
-			if t, hasTmpl := templates["rss"]; dirname == "" && hasTmpl {
+			if t, hasTmpl := templates["rss"]; dirname == "/" && hasTmpl {
 				tmpl = t
 			} else {
 				tmpl = defaultRssTemplate

--- a/cmd/gmnhg/main.go
+++ b/cmd/gmnhg/main.go
@@ -462,7 +462,7 @@ func main() {
 		cnt := map[string]interface{}{
 			"Posts":   posts,
 			"Dirname": dirname,
-			"Link":    dirname + "/" + rssFilename,
+			"Link":    path.Join(dirname, rssFilename),
 			"Site":    sc,
 		}
 		buf := bytes.Buffer{}

--- a/cmd/gmnhg/main.go
+++ b/cmd/gmnhg/main.go
@@ -448,7 +448,7 @@ func main() {
 		if hasSubPath(leafIndexPaths, path.Join(contentBase, dirname)+"/") {
 			continue
 		}
-		tmpl, hasTmpl := templates["top"+dirname+".rss"]
+		tmpl, hasTmpl := templates["top"+dirname+"_rss"]
 		if !hasTmpl {
 			if rootTmpl, hasTmpl := templates["rss"]; dirname == "/" && hasTmpl {
 				tmpl = rootTmpl

--- a/cmd/gmnhg/templates.go
+++ b/cmd/gmnhg/templates.go
@@ -54,23 +54,23 @@ var defaultRssTemplate = mustParseTmpl("rss", `{{- $Site := .Site -}}
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-    <title>{{ if $Site.Title }}{{ $Site.Title }}{{ else }}Site feed{{ with .Dirname }} for {{.}}{{end}}{{end}}</title>
-    <link>{{ $Site.GeminiBaseURL }}{{ .Link }}</link>
-    <description>Recent content{{ with .Dirname }} in {{.}}{{end}}{{ with $Site.Title }} on {{.}}{{end}}</description>
+    <title>{{ if $Site.Title }}{{ html $Site.Title }}{{ else }}Site feed{{ with .Dirname }} for {{ html . }}{{end}}{{end}}</title>
+    <link>{{ html (list (trimSuffix "/" $Site.GeminiBaseURL) .Link | join "/") }}</link>
+    <description>Recent content{{ with .Dirname }} in {{ html . }}{{end}}{{ with $Site.Title }} on {{ html . }}{{end}}</description>
     <generator>gmnhg</generator>{{ with $Site.LanguageCode }}
-    <language>{{.}}</language>{{end}}{{ with $Site.Author.email }}
-    <managingEditor>{{.}}{{ with $Site.Author.name }} ({{.}}){{end}}</managingEditor>
-    <webMaster>{{.}}{{ with $Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with $Site.Copyright }}
-    <copyright>{{.}}</copyright>{{end}}
+    <language>{{ html .}}</language>{{end}}{{ with $Site.Author.email }}
+    <managingEditor>{{ html . }}{{ with $Site.Author.name }} ({{ html . }}){{end}}</managingEditor>
+    <webMaster>{{ html . }}{{ with $Site.Author.name }} ({{ html . }}){{end}}</webMaster>{{end}}{{ with $Site.Copyright }}
+    <copyright>{{ html . }}</copyright>{{end}}
     <lastBuildDate>{{ now.Format "Mon, 02 Jan 2006 15:04:05 -0700" }}</lastBuildDate>
-    {{ printf "<atom:link href=%q rel=\"self\" type=\"application/rss+xml\" />" .Link }}
+    {{ printf "<atom:link href=%q rel=\"self\" type=\"application/rss+xml\" />" (html .Link) }}
     {{ range $i, $p := .Posts | sortPosts }}{{ if lt $i 25 }}
     <item>
-      <title>{{ if $p.Metadata.PostTitle }}{{ $p.Metadata.PostTitle }}{{ else }}{{ $p.Link }}{{end}}</title>
-      <link>{{ $Site.GeminiBaseURL }}{{ $p.Link }}</link>
+      <title>{{ if $p.Metadata.PostTitle }}{{ html $p.Metadata.PostTitle }}{{ else }}{{ html $p.Link }}{{end}}</title>
+      <link>{{ html (list (trimSuffix "/" $Site.GeminiBaseURL) $p.Link | join "/") }}</link>
       <pubDate>{{ $p.Metadata.PostDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" }}</pubDate>
-      <guid>{{ $Site.GeminiBaseURL }}{{ $p.Link }}</guid>
-      <description>{{ $p.Metadata.PostSummary }}</description>
+      <guid>{{ html (list (trimSuffix "/" $Site.GeminiBaseURL) $p.Link | join "/") }}</guid>
+      <description>{{ html $p.Metadata.PostSummary }}</description>
     </item>
     {{end}}{{end}}
   </channel>

--- a/cmd/gmnhg/templates.go
+++ b/cmd/gmnhg/templates.go
@@ -53,11 +53,13 @@ Index of {{ trimPrefix "/" $dir }}:
 
 var defaultRssTemplate = mustParseTmpl("rss", `{{- $Site := .Site -}}
 {{- $Dirname := trimPrefix "/" .Dirname -}}
+{{- $DirLink := list (trimSuffix "/" $Site.GeminiBaseURL) $Dirname | join "/" | html -}}
+{{- $RssLink := list (trimSuffix "/" $Site.GeminiBaseURL) (trimPrefix "/" .Link) | join "/" | html -}}
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>{{ if $Site.Title }}{{ html $Site.Title }}{{ else }}Site feed{{ with $Dirname }} for {{ html . }}{{end}}{{end}}</title>
-    <link>{{ html (list (trimSuffix "/" $Site.GeminiBaseURL) .Link | join "/") }}</link>
+    <link>{{ $DirLink }}</link>
     <description>Recent content{{ with $Dirname }} in {{ html . }}{{end}}{{ with $Site.Title }} on {{ html . }}{{end}}</description>
     <generator>gmnhg</generator>{{ with $Site.LanguageCode }}
     <language>{{ html .}}</language>{{end}}{{ with $Site.Author.email }}
@@ -65,13 +67,14 @@ var defaultRssTemplate = mustParseTmpl("rss", `{{- $Site := .Site -}}
     <webMaster>{{ html . }}{{ with $Site.Author.name }} ({{ html . }}){{end}}</webMaster>{{end}}{{ with $Site.Copyright }}
     <copyright>{{ html . }}</copyright>{{end}}
     <lastBuildDate>{{ now.Format "Mon, 02 Jan 2006 15:04:05 -0700" }}</lastBuildDate>
-    {{ printf "<atom:link href=%q rel=\"self\" type=\"application/rss+xml\" />" (html .Link) }}
+    {{ printf "<atom:link href=%q rel=\"self\" type=\"application/rss+xml\" />" $RssLink }}
     {{ range $i, $p := .Posts | sortPosts }}{{ if lt $i 25 }}
+    {{- $AbsURL := list (trimSuffix "/" $Site.GeminiBaseURL) (trimPrefix "/" (regexReplaceAll "/index\\.gmi$" $p.Link "/")) | join "/" | html }}
     <item>
-      <title>{{ if $p.Metadata.PostTitle }}{{ html $p.Metadata.PostTitle }}{{ else }}{{ html $p.Link }}{{end}}</title>
-      <link>{{ html (list (trimSuffix "/" $Site.GeminiBaseURL) (regexReplaceAll "/index\\.gmi$" $p.Link "/") | join "/") }}</link>
+      <title>{{ if $p.Metadata.PostTitle }}{{ html $p.Metadata.PostTitle }}{{ else }}{{ trimPrefix "/" $p.Link | html }}{{end}}</title>
+      <link>{{ $AbsURL }}</link>
       <pubDate>{{ $p.Metadata.PostDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" }}</pubDate>
-      <guid>{{ html (list (trimSuffix "/" $Site.GeminiBaseURL) (regexReplaceAll "/index\\.gmi$" $p.Link "/") | join "/") }}</guid>
+      <guid>{{ $AbsURL }}</guid>
       <description>{{ html $p.Metadata.PostSummary }}</description>
     </item>
     {{end}}{{end}}

--- a/cmd/gmnhg/templates.go
+++ b/cmd/gmnhg/templates.go
@@ -49,3 +49,30 @@ var defaultIndexTemplate = mustParseTmpl("index", `# Site index
 {{ range $p := $posts | sortPosts }}=> {{ $p.Link }} {{ $p.Metadata.PostDate.Format "2006-01-02 15:04" }} - {{ $p.Metadata.PostTitle }}
 {{ end }}{{ end }}
 `)
+
+var defaultRssTemplate = mustParseTmpl("rss", `{{- $Site := .Site -}}
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ if $Site.Title }}{{ $Site.Title }}{{ else }}Site feed{{ with .Dirname }} for {{.}}{{end}}{{end}}</title>
+    <link>{{ $Site.GeminiBaseURL }}{{ .Link }}</link>
+    <description>Recent content{{ with .Dirname }} in {{.}}{{end}}{{ with $Site.Title }} on {{.}}{{end}}</description>
+    <generator>gmnhg</generator>{{ with $Site.LanguageCode }}
+    <language>{{.}}</language>{{end}}{{ with $Site.Author.email }}
+    <managingEditor>{{.}}{{ with $Site.Author.name }} ({{.}}){{end}}</managingEditor>
+    <webMaster>{{.}}{{ with $Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with $Site.Copyright }}
+    <copyright>{{.}}</copyright>{{end}}
+    <lastBuildDate>{{ now.Format "Mon, 02 Jan 2006 15:04:05 -0700" }}</lastBuildDate>
+    {{ printf "<atom:link href=%q rel=\"self\" type=\"application/rss+xml\" />" .Link }}
+    {{ range $i, $p := .Posts | sortPosts }}{{ if lt $i 25 }}
+    <item>
+      <title>{{ if $p.Metadata.PostTitle }}{{ $p.Metadata.PostTitle }}{{ else }}{{ $p.Link }}{{end}}</title>
+      <link>{{ $Site.GeminiBaseURL }}{{ $p.Link }}</link>
+      <pubDate>{{ $p.Metadata.PostDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" }}</pubDate>
+      <guid>{{ $Site.GeminiBaseURL }}{{ $p.Link }}</guid>
+      <description>{{ $p.Metadata.PostSummary }}</description>
+    </item>
+    {{end}}{{end}}
+  </channel>
+</rss>
+`)

--- a/cmd/gmnhg/templates.go
+++ b/cmd/gmnhg/templates.go
@@ -47,7 +47,7 @@ var defaultIndexTemplate = mustParseTmpl("index", `# Site index
 {{- range $dir, $posts := .PostData }}{{ if and (ne $dir "/") (eq (dir $dir) "/") }}
 Index of {{ trimPrefix "/" $dir }}:
 
-{{ range $p := $posts | sortPosts }}=> $p.Link {{ $p.Metadata.PostDate.Format "2006-01-02 15:04" }}{{ with $p.Metadata.PostTitle }} - {{ . }}{{end}}
+{{ range $p := $posts | sortPosts }}=> {{ $p.Link }} {{ $p.Metadata.PostDate.Format "2006-01-02 15:04" }}{{ with $p.Metadata.PostTitle }} - {{ . }}{{end}}
 {{ end }}{{ end }}{{ end }}
 `)
 

--- a/cmd/gmnhg/templates.go
+++ b/cmd/gmnhg/templates.go
@@ -47,7 +47,7 @@ var defaultIndexTemplate = mustParseTmpl("index", `# Site index
 {{- range $dir, $posts := .PostData }}{{ if and (ne $dir "/") (eq (dir $dir) "/") }}
 Index of {{ trimPrefix "/" $dir }}:
 
-{{ range $p := $posts | sortPosts }}=> {{ $p.Link }} {{ $p.Metadata.PostDate.Format "2006-01-02 15:04" }}{{ with $p.Metadata.PostTitle }} - {{ . }}{{end}}
+{{ range $p := $posts | sortPosts }}=> {{ $p.Link }} {{ $p.Metadata.PostDate.Format "2006-01-02 15:04" }} - {{ if $p.Metadata.PostTitle }}{{ $p.Metadata.PostTitle }}{{else}}{{ $p.Link }}{{end}}
 {{ end }}{{ end }}{{ end }}
 `)
 

--- a/cmd/gmnhg/templates.go
+++ b/cmd/gmnhg/templates.go
@@ -44,10 +44,10 @@ var defaultSingleTemplate = mustParseTmpl("single", `# {{ .Metadata.PostTitle }}
 var defaultIndexTemplate = mustParseTmpl("index", `# Site index
 
 {{ with .Content }}{{ printf "%s" . -}}{{ end }}
-{{ range $dir, $posts := .PostData }}Index of {{ $dir }}:
+{{ range $dir, $posts := .PostData }}{{ if $dir }}Index of {{ $dir }}:
 
 {{ range $p := $posts | sortPosts }}=> {{ $p.Link }} {{ $p.Metadata.PostDate.Format "2006-01-02 15:04" }} - {{ $p.Metadata.PostTitle }}
-{{ end }}{{ end }}
+{{ end }}{{ end }}{{ end }}
 `)
 
 var defaultRssTemplate = mustParseTmpl("rss", `{{- $Site := .Site -}}

--- a/cmd/gmnhg/templates.go
+++ b/cmd/gmnhg/templates.go
@@ -47,7 +47,7 @@ var defaultIndexTemplate = mustParseTmpl("index", `# Site index
 {{- range $dir, $posts := .PostData }}{{ if and (ne $dir "/") (eq (dir $dir) "/") }}
 Index of {{ trimPrefix "/" $dir }}:
 
-{{ range $p := $posts | sortPosts }}=> {{ regexReplaceAll "/index\\.gmi$" $p.Link "/" }} {{ $p.Metadata.PostDate.Format "2006-01-02 15:04" }}{{ with $p.Metadata.PostTitle }} - {{ . }}{{end}}
+{{ range $p := $posts | sortPosts }}=> $p.Link {{ $p.Metadata.PostDate.Format "2006-01-02 15:04" }}{{ with $p.Metadata.PostTitle }} - {{ . }}{{end}}
 {{ end }}{{ end }}{{ end }}
 `)
 
@@ -69,7 +69,7 @@ var defaultRssTemplate = mustParseTmpl("rss", `{{- $Site := .Site -}}
     <lastBuildDate>{{ now.Format "Mon, 02 Jan 2006 15:04:05 -0700" }}</lastBuildDate>
     {{ printf "<atom:link href=%q rel=\"self\" type=\"application/rss+xml\" />" $RssLink }}
     {{ range $i, $p := .Posts | sortPosts }}{{ if lt $i 25 }}
-    {{- $AbsURL := list (trimSuffix "/" $Site.GeminiBaseURL) (trimPrefix "/" (regexReplaceAll "/index\\.gmi$" $p.Link "/")) | join "/" | html }}
+    {{- $AbsURL := list (trimSuffix "/" $Site.GeminiBaseURL) (trimPrefix "/" $p.Link) | join "/" | html }}
     <item>
       <title>{{ if $p.Metadata.PostTitle }}{{ html $p.Metadata.PostTitle }}{{ else }}{{ trimPrefix "/" $p.Link | html }}{{end}}</title>
       <link>{{ $AbsURL }}</link>

--- a/cmd/gmnhg/templates.go
+++ b/cmd/gmnhg/templates.go
@@ -51,12 +51,13 @@ var defaultIndexTemplate = mustParseTmpl("index", `# Site index
 `)
 
 var defaultRssTemplate = mustParseTmpl("rss", `{{- $Site := .Site -}}
+{{- $Dirname := trimPrefix "/" .Dirname -}}
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>{{ if $Site.Title }}{{ html $Site.Title }}{{ else }}Site feed{{ with .Dirname }} for {{ html . }}{{end}}{{end}}</title>
     <link>{{ html (list (trimSuffix "/" $Site.GeminiBaseURL) .Link | join "/") }}</link>
-    <description>Recent content{{ with .Dirname }} in {{ html . }}{{end}}{{ with $Site.Title }} on {{ html . }}{{end}}</description>
+    <description>Recent content{{ with $Dirname }} in {{ html . }}{{end}}{{ with $Site.Title }} on {{ html . }}{{end}}</description>
     <generator>gmnhg</generator>{{ with $Site.LanguageCode }}
     <language>{{ html .}}</language>{{end}}{{ with $Site.Author.email }}
     <managingEditor>{{ html . }}{{ with $Site.Author.name }} ({{ html . }}){{end}}</managingEditor>

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/tdemin/gmnhg
 go 1.16
 
 require (
+	github.com/BurntSushi/toml v0.4.1
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/gomarkdown/markdown v0.0.0-20210514010506-3b9f47219fe7
 	github.com/mattn/go-runewidth v0.0.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v0.4.1 h1:GaI7EiDXDRfa8VshkTj7Fym7ha+y8/XxIgD2okUIjLw=
+github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=

--- a/render.go
+++ b/render.go
@@ -36,6 +36,7 @@ type HugoMetadata struct {
 	PostIsDraft bool      `yaml:"draft"`
 	PostLayout  string    `yaml:"layout"`
 	PostDate    time.Time `yaml:"date"`
+	PostSummary string    `yaml:"summary"`
 	IsHeadless  bool      `yaml:"headless"`
 }
 


### PR DESCRIPTION
This relies on the site config to provide a custom GeminiBaseURL setting, as well as the site title, copyright, and language. Hopefully this could be useful elsewhere. I have only tested it with a TOML config so far but the others should work. I have also only tested with the default RSS template, I haven't tried to override it yet... so there may be bugs in that feature.

I decided that adding a "GeminiBaseURL" config option is probably the only solution besides a command line switch or extra config file. I've noticed that lots of people run their Gemini site on a separate subdomain from their main site.

Note: I made a change to topLevelPosts, and added an empty string key that holds everything. This gives both the RSS feed and the main index a way to easily access all posts. I had to update the main index template to avoid a change in behavior, but this was helpful for keeping the RSS generation code relatively clean.