### PR TITLE
Update templates.go to use new metadata

### DIFF
--- a/cmd/gmnhg/templates.go
+++ b/cmd/gmnhg/templates.go
@@ -35,9 +35,9 @@ func defineFuncMap() template.FuncMap {
 	return fm
 }
 
-var defaultSingleTemplate = mustParseTmpl("single", `# {{ .Metadata.PostTitle }}
+var defaultSingleTemplate = mustParseTmpl("single", `# {{ .Metadata.Title }}
 
-{{ .Metadata.PostDate.Format "2006-01-02 15:04" }}
+{{ .Metadata.Date.Format "2006-01-02 15:04" }}
 
 {{ printf "%s" .Post }}`)
 
@@ -47,7 +47,7 @@ var defaultIndexTemplate = mustParseTmpl("index", `# Site index
 {{- range $dir, $posts := .PostData }}{{ if and (ne $dir "/") (eq (dir $dir) "/") }}
 Index of {{ trimPrefix "/" $dir }}:
 
-{{ range $p := $posts | sortPosts }}=> {{ $p.Link }} {{ $p.Metadata.PostDate.Format "2006-01-02 15:04" }} - {{ if $p.Metadata.PostTitle }}{{ $p.Metadata.PostTitle }}{{else}}{{ $p.Link }}{{end}}
+{{ range $p := $posts | sortPosts }}=> {{ $p.Link }} {{ $p.Metadata.Date.Format "2006-01-02 15:04" }} - {{ if $p.Metadata.Title }}{{ $p.Metadata.Title }}{{else}}{{ $p.Link }}{{end}}
 {{ end }}{{ end }}{{ end }}
 `)
 
@@ -71,11 +71,11 @@ var defaultRssTemplate = mustParseTmpl("rss", `{{- $Site := .Site -}}
     {{ range $i, $p := .Posts | sortPosts }}{{ if lt $i 25 }}
     {{- $AbsURL := list (trimSuffix "/" $Site.GeminiBaseURL) (trimPrefix "/" $p.Link) | join "/" | html }}
     <item>
-      <title>{{ if $p.Metadata.PostTitle }}{{ html $p.Metadata.PostTitle }}{{ else }}{{ trimPrefix "/" $p.Link | html }}{{end}}</title>
+      <title>{{ if $p.Metadata.Title }}{{ html $p.Metadata.Title }}{{ else }}{{ trimPrefix "/" $p.Link | html }}{{end}}</title>
       <link>{{ $AbsURL }}</link>
-      <pubDate>{{ $p.Metadata.PostDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" }}</pubDate>
+      <pubDate>{{ $p.Metadata.Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" }}</pubDate>
       <guid>{{ $AbsURL }}</guid>
-      <description>{{ html $p.Metadata.PostSummary }}</description>
+      <description>{{ html $p.Metadata.Summary }}</description>
     </item>
     {{end}}{{end}}
   </channel>


### PR DESCRIPTION
Removed "Post" prefix from template vars like "PostTitle" (now just "Title") so default templates will work with recent metadata changes