### PR TITLE
Config parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,26 @@ can be used as a standalone program as well.
 
 ## Site configuration
 
-For RSS feeds to use correct URLs, you should define `geminiBaseURL` in
-Hugo's configuration file (`config.toml`, `config.yaml`, or
-`config.json`).
+gmnhg will pick up some attributes such as site title, base URL, and
+language code from your Hugo configuration file (`config.toml`,
+`config.yaml`, or `config.json`). Presently these are used in the
+default RSS template.
 
-Other attributes from this file, such as site title, will also be used
-during RSS feed generation if they are defined.
+gmnhg provides a way to override these attributes by defining a
+`gmnhg` section in the configuration file and nesting the attributes
+to override underneath this section. Presently you can override both
+`baseUrl` and `title` in this manner.
+
+For example, you could add the following to your `config.toml` to
+override your `baseUrl`:
+
+```
+[gmnhg]
+baseUrl = "gemini://mysite.com"
+```
+
+This is recommended, as it will ensure that RSS links on your Gemini
+site use the correct URL.
 
 ## License
 

--- a/cmd/gmnhg/main.go
+++ b/cmd/gmnhg/main.go
@@ -83,10 +83,12 @@
 // loaded from the Hugo configuration file (config.toml, config.yaml,
 // or config.json).
 //
-// A new setting, geminiBaseURL, should be added to the Hugo
-// configuration file to ensure that RSS paths are correct. This is
-// more or less the same as Hugo's baseURL, but is separate in case
-// your Gemini site is deployed to a different server.
+// gmnhg provides a way to override these attributes by defining a
+// `gmnhg` section in the configuration file and nesting the attributes
+// to override underneath this section. Presently you can override both
+// `baseUrl` and `title` in this manner. It is recommended to override
+// at least `baseUrl` unless your site uses a protocol-relative base
+// URL (beginning with a double slash instead of https://).
 //
 // RSS templates can be overriden by defining a template in one of
 // several places:
@@ -148,10 +150,16 @@ var (
 var hugoConfigFiles = []string{"config.toml", "config.yaml", "config.json"}
 
 type SiteConfig struct {
-	GeminiBaseURL string `yaml:"geminiBaseURL"`
-	Title         string `yaml:"title"`
-	Copyright     string `yaml:"copyright"`
-	LanguageCode  string `yaml:"languageCode"`
+	BaseURL      string      `yaml:"baseURL"`
+	Title        string      `yaml:"title"`
+	Copyright    string      `yaml:"copyright"`
+	LanguageCode string      `yaml:"languageCode"`
+	Gmnhg        GmnhgConfig `yaml:"gmnhg"`
+}
+
+type GmnhgConfig struct {
+	BaseURL string `yaml:"baseURL"`
+	Title   string `yaml:"title"`
 }
 
 func copyFile(dst, src string) error {
@@ -200,6 +208,14 @@ func hasSubPath(paths []string, path string) bool {
 		}
 	}
 	return false
+}
+
+func ifNotEmptyElse(first string, second string) string {
+	if first != "" {
+		return first
+	} else {
+		return second
+	}
 }
 
 var version = "v0+HEAD"
@@ -476,10 +492,10 @@ func main() {
 			}
 		}
 		sc := map[string]interface{}{
-			"GeminiBaseURL": siteConf.GeminiBaseURL,
-			"Title":         siteConf.Title,
-			"Copyright":     siteConf.Copyright,
-			"LanguageCode":  siteConf.LanguageCode,
+			"BaseURL":      ifNotEmptyElse(siteConf.Gmnhg.BaseURL, siteConf.BaseURL),
+			"Title":        ifNotEmptyElse(siteConf.Gmnhg.Title, siteConf.Title),
+			"Copyright":    siteConf.Copyright,
+			"LanguageCode": siteConf.LanguageCode,
 		}
 		cnt := map[string]interface{}{
 			"Posts":   posts,

--- a/cmd/gmnhg/templates.go
+++ b/cmd/gmnhg/templates.go
@@ -35,9 +35,9 @@ func defineFuncMap() template.FuncMap {
 	return fm
 }
 
-var defaultSingleTemplate = mustParseTmpl("single", `# {{ .Metadata.PostTitle }}
+var defaultSingleTemplate = mustParseTmpl("single", `# {{ .Metadata.Title }}
 
-{{ .Metadata.PostDate.Format "2006-01-02 15:04" }}
+{{ .Metadata.Date.Format "2006-01-02 15:04" }}
 
 {{ printf "%s" .Post }}`)
 
@@ -47,7 +47,7 @@ var defaultIndexTemplate = mustParseTmpl("index", `# Site index
 {{- range $dir, $posts := .PostData }}{{ if and (ne $dir "/") (eq (dir $dir) "/") }}
 Index of {{ trimPrefix "/" $dir }}:
 
-{{ range $p := $posts | sortPosts }}=> {{ $p.Link }} {{ $p.Metadata.PostDate.Format "2006-01-02 15:04" }} - {{ if $p.Metadata.PostTitle }}{{ $p.Metadata.PostTitle }}{{else}}{{ $p.Link }}{{end}}
+{{ range $p := $posts | sortPosts }}=> {{ $p.Link }} {{ $p.Metadata.Date.Format "2006-01-02 15:04" }} - {{ if $p.Metadata.Title }}{{ $p.Metadata.Title }}{{else}}{{ $p.Link }}{{end}}
 {{ end }}{{ end }}{{ end }}
 `)
 
@@ -71,11 +71,11 @@ var defaultRssTemplate = mustParseTmpl("rss", `{{- $Site := .Site -}}
     {{ range $i, $p := .Posts | sortPosts }}{{ if lt $i 25 }}
     {{- $AbsURL := list (trimSuffix "/" $Site.GeminiBaseURL) (trimPrefix "/" $p.Link) | join "/" | html }}
     <item>
-      <title>{{ if $p.Metadata.PostTitle }}{{ html $p.Metadata.PostTitle }}{{ else }}{{ trimPrefix "/" $p.Link | html }}{{end}}</title>
+      <title>{{ if $p.Metadata.Title }}{{ html $p.Metadata.Title }}{{ else }}{{ trimPrefix "/" $p.Link | html }}{{end}}</title>
       <link>{{ $AbsURL }}</link>
-      <pubDate>{{ $p.Metadata.PostDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" }}</pubDate>
+      <pubDate>{{ $p.Metadata.Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" }}</pubDate>
       <guid>{{ $AbsURL }}</guid>
-      <description>{{ html $p.Metadata.PostSummary }}</description>
+      <description>{{ html $p.Metadata.Summary }}</description>
     </item>
     {{end}}{{end}}
   </channel>

--- a/cmd/gmnhg/templates.go
+++ b/cmd/gmnhg/templates.go
@@ -53,8 +53,8 @@ Index of {{ trimPrefix "/" $dir }}:
 
 var defaultRssTemplate = mustParseTmpl("rss", `{{- $Site := .Site -}}
 {{- $Dirname := trimPrefix "/" .Dirname -}}
-{{- $DirLink := list (trimSuffix "/" $Site.GeminiBaseURL) $Dirname | join "/" | html -}}
-{{- $RssLink := list (trimSuffix "/" $Site.GeminiBaseURL) (trimPrefix "/" .Link) | join "/" | html -}}
+{{- $DirLink := list (trimSuffix "/" $Site.BaseURL) $Dirname | join "/" | html -}}
+{{- $RssLink := list (trimSuffix "/" $Site.BaseURL) (trimPrefix "/" .Link) | join "/" | html -}}
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
@@ -69,7 +69,7 @@ var defaultRssTemplate = mustParseTmpl("rss", `{{- $Site := .Site -}}
     <lastBuildDate>{{ now.Format "Mon, 02 Jan 2006 15:04:05 -0700" }}</lastBuildDate>
     {{ printf "<atom:link href=%q rel=\"self\" type=\"application/rss+xml\" />" $RssLink }}
     {{ range $i, $p := .Posts | sortPosts }}{{ if lt $i 25 }}
-    {{- $AbsURL := list (trimSuffix "/" $Site.GeminiBaseURL) (trimPrefix "/" $p.Link) | join "/" | html }}
+    {{- $AbsURL := list (trimSuffix "/" $Site.BaseURL) (trimPrefix "/" $p.Link) | join "/" | html }}
     <item>
       <title>{{ if $p.Metadata.Title }}{{ html $p.Metadata.Title }}{{ else }}{{ trimPrefix "/" $p.Link | html }}{{end}}</title>
       <link>{{ $AbsURL }}</link>


### PR DESCRIPTION
Based on #31 patch but I made this separate.

This now uses the default `baseUrl` and `title` from the Hugo configuration, unless a `gmnhg` section is defined and an override `baseUrl` and/or `title` is supplied there.

If you use a protocol-relative base URL like //mysite.com then you don't need to define a override. But some people host their Gemini sites on different domains or subdomains, so this supports that without adding extra junk to the main Hugo configuration namespace.

I didn't see a reason to add overrides for copyright or language code, but that's trivial to add if anyone ever needs it.

Closes #29.