### PR TITLE
Add author name/email for RSS template

### DIFF
--- a/cmd/gmnhg/main.go
+++ b/cmd/gmnhg/main.go
@@ -150,16 +150,22 @@ var (
 var hugoConfigFiles = []string{"config.toml", "config.yaml", "config.json"}
 
 type SiteConfig struct {
-	BaseURL      string      `yaml:"baseURL"`
-	Title        string      `yaml:"title"`
-	Copyright    string      `yaml:"copyright"`
-	LanguageCode string      `yaml:"languageCode"`
-	Gmnhg        GmnhgConfig `yaml:"gmnhg"`
+	BaseURL      string       `yaml:"baseURL"`
+	Title        string       `yaml:"title"`
+	Copyright    string       `yaml:"copyright"`
+	LanguageCode string       `yaml:"languageCode"`
+	Author       AuthorConfig `yaml:"author"`
+	Gmnhg        GmnhgConfig  `yaml:"gmnhg"`
 }
 
 type GmnhgConfig struct {
 	BaseURL string `yaml:"baseURL"`
 	Title   string `yaml:"title"`
+}
+
+type AuthorConfig struct {
+	Name  string `yaml:"name"`
+	Email string `yaml:"email"`
 }
 
 func copyFile(dst, src string) error {
@@ -490,6 +496,8 @@ func main() {
 			"GmnhgTitle":   siteConf.Gmnhg.Title,
 			"Copyright":    siteConf.Copyright,
 			"LanguageCode": siteConf.LanguageCode,
+			"AuthorName":	  siteConf.Author.Name,
+			"AuthorEmail":  siteConf.Author.Email,
 		}
 		cnt := map[string]interface{}{
 			"Posts":   posts,

--- a/cmd/gmnhg/templates.go
+++ b/cmd/gmnhg/templates.go
@@ -65,9 +65,9 @@ var defaultRssTemplate = mustParseTmpl("rss", `{{- $Site := .Site -}}
     <link>{{ $DirURL }}</link>
     <description>Recent content{{ with $Dirname }} in {{ . }}{{end}}{{ with $SiteTitle }} on {{ . }}{{end}}</description>
     <generator>gmnhg</generator>{{ with $Site.LanguageCode }}
-    <language>{{ html .}}</language>{{end}}{{ with $Site.Author.email }}
-    <managingEditor>{{ html . }}{{ with $Site.Author.name }} ({{ html . }}){{end}}</managingEditor>
-    <webMaster>{{ html . }}{{ with $Site.Author.name }} ({{ html . }}){{end}}</webMaster>{{end}}{{ with $Site.Copyright }}
+    <language>{{ html .}}</language>{{end}}{{ with $Site.AuthorEmail }}
+    <managingEditor>{{ html . }}{{ with $Site.AuthorName }} ({{ html . }}){{end}}</managingEditor>
+    <webMaster>{{ html . }}{{ with $Site.AuthorName }} ({{ html . }}){{end}}</webMaster>{{end}}{{ with $Site.Copyright }}
     <copyright>{{ html . }}</copyright>{{end}}
     <lastBuildDate>{{ now.Format "Mon, 02 Jan 2006 15:04:05 -0700" }}</lastBuildDate>
     {{ printf "<atom:link href=%q rel=\"self\" type=\"application/rss+xml\" />" $RssURL }}


### PR DESCRIPTION
Added parsing of author attributes, needed to complete the default RSS template. This uses the same configuration variables that the default Hugo RSS template uses. They are optional, RSS works fine without them.