### PR TITLE
Clean up templates and unify template metadata

### DIFF
--- a/cmd/gmnhg/main.go
+++ b/cmd/gmnhg/main.go
@@ -430,10 +430,20 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
+		sc := map[string]interface{}{
+			"BaseURL":      siteConf.BaseURL,
+			"GmnhgBaseURL": siteConf.Gmnhg.BaseURL,
+			"Title":        siteConf.Title,
+			"GmnhgTitle":   siteConf.Gmnhg.Title,
+			"Copyright":    siteConf.Copyright,
+			"LanguageCode": siteConf.LanguageCode,
+		}
 		cnt := map[string]interface{}{
 			"Posts":   posts,
 			"Dirname": dirname,
+			"Link":    path.Join(dirname, indexFilename),
 			"Content": gemtext,
+			"Site":    sc,
 		}
 		buf := bytes.Buffer{}
 		if err := tmpl.Execute(&buf, cnt); err != nil {
@@ -457,8 +467,22 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	sc := map[string]interface{}{
+		"BaseURL":      siteConf.BaseURL,
+		"GmnhgBaseURL": siteConf.Gmnhg.BaseURL,
+		"Title":        siteConf.Title,
+		"GmnhgTitle":   siteConf.Gmnhg.Title,
+		"Copyright":    siteConf.Copyright,
+		"LanguageCode": siteConf.LanguageCode,
+	}
+	cnt := map[string]interface{}{
+		"Posts":   topLevelPosts,
+		"Dirname": "/",
+		"Link":    path.Join("/", indexFilename),
+		"Content": gemtext,
+		"Site":    sc,
+	}
 	buf := bytes.Buffer{}
-	cnt := map[string]interface{}{"PostData": topLevelPosts, "Content": gemtext}
 	if err := indexTmpl.Execute(&buf, cnt); err != nil {
 		panic(err)
 	}

--- a/cmd/gmnhg/main.go
+++ b/cmd/gmnhg/main.go
@@ -46,22 +46,29 @@
 //
 // 1. Single pages are given .Post, which contains the entire post
 // rendered, .Metadata, which contains the metadata crawled from it (see
-// HugoMetadata), and .Link, which contains the filename relative to
-// content dir (with .md replaced with .gmi).
+// Metadata in internal/gmnhg/post.go), and .Link, which contains the
+// filename relative to content dir (with .md replaced with .gmi). 
 //
-// 2. Directory index pages are passed .Posts, which is a slice over
-// post metadata crawled (see HugoMetadata), .Dirname, which is
-// directory name relative to content dir, and .Content, which is
-// rendered from directory's _index.gmi.md.
+// 2. Directory index pages, including the top-level index, are passed
+// .Posts, which is a slice over post metadata crawled (see Metadata in
+// internal/gmnhg/post.go), .Dirname, which is the directory name
+// relative to the content dir, .Link, which contains the index filename
+// relative to the content dir (with .md replaced with .gmi), .Content,
+// which is rendered from directory's _index.gmi.md, and .Site, which
+// contains site-level configuration data loaded from the Hugo site's
+// config.toml, config.yaml, or config.json.
+//
+// The following keys are available in the .Site map, listed with their
+// associated Hugo configuration key: .BaseURL (baseUrl), .GmnhgBaseURL,
+// (gmnhg.baseUrl), .Title (title), .GmnhgTitle (gmnhg.title), .Copyright
+// (copyright), and .LanguageCode (languageCode).
 //
 // Directory indices are passed all posts from subdirectories (branch
 // and leaf bundles), with the exception of leaf resource pages. This
 // allows for roll-up indices.
 //
-// 3. The top-level index.gmi is passed with the .PostData map whose
-// keys are top-level content directories names and values are slices
-// over the same post props as specified in 1, and .Content, which is
-// rendered from top-level _index.gmi.md.
+// 3. RSS templates receive the same data as directory index pages, but
+// the filename provided by .Link is rss.xml instead of index.gmi.
 //
 // This program provides some extra template functions on top of sort:
 //

--- a/cmd/gmnhg/templates.go
+++ b/cmd/gmnhg/templates.go
@@ -35,11 +35,11 @@ func defineFuncMap() template.FuncMap {
 	return fm
 }
 
-var defaultSingleTemplate = mustParseTmpl("single", `# {{ or .Metadata.Title (trimPrefix "/" .Link) }}
-{{ if not .Metadata.Date.IsZero }}
-{{ .Metadata.Date.Format "2006-01-02 15:04" }}
-{{ end }}
-{{ printf "%s" .Post }}`)
+var defaultSingleTemplate = mustParseTmpl("single", `{{ with .Metadata.Title }}# {{.}}
+
+{{ end }}{{ if not .Metadata.Date.IsZero }}{{ .Metadata.Date.Format "2006-01-02 15:04" }}
+
+{{ end }}{{ printf "%s" .Post }}`)
 
 var defaultIndexTemplate = mustParseTmpl("index", `# {{ or .Site.GmnhgTitle (or .Site.Title "Site index") }}
 {{ with .Content }}


### PR DESCRIPTION
This does several things:

- Removes unused and unavailable metadata from the RSS template
- Passes site config data to index templates
- Updates the default index template data to use the same names as other templates **(breaking change, .PostData is now .Posts in main index)** - note that index/top template code is now mostly identical, so it should be possible to consolidate this code
- Update default index template to use the site title if present and to skip printing dates if unavailable
- Update default single page template to use the page link if no title is present and to skip printing the post date if no date is present

With these changes, users should be able to run gmnhg out of the box with no configuration and get a reasonable default site, with their site's title reflected in the main index. All pages will render OK even if they have no title or date set.