### PR TITLE
Encode link URIs before rendering into Gemtext

### DIFF
--- a/internal/renderer/link.go
+++ b/internal/renderer/link.go
@@ -18,6 +18,7 @@ package renderer
 import (
 	"fmt"
 	"io"
+	"net/url"
 
 	"github.com/gomarkdown/markdown/ast"
 )
@@ -27,8 +28,13 @@ func (r Renderer) link(w io.Writer, node *ast.Link, entering bool) {
 		if node.Footnote != nil {
 			fmt.Fprintf(w, "[^%d]: %s", node.NoteID, extractText(node.Footnote))
 		} else {
+			uri, err := url.Parse(string(node.Destination))
+			if err != nil {
+				// TODO: should we skip links with invalid URIs?
+				return
+			}
 			w.Write(linkPrefix)
-			w.Write(node.Destination)
+			w.Write([]byte(uri.String()))
 			w.Write(space)
 			r.text(w, node, true)
 		}

--- a/testdata/links.gmi
+++ b/testdata/links.gmi
@@ -26,6 +26,10 @@ Other container elements can contain inline links as well. For instance, this is
 
 => https://xmpp.org/extensions/xep-0384.html XEP-0384
 
+Links will get encoded according to RFC 3986, like this sample link to nowhere.
+
+=> /URI%20with%20spaces link
+
 ## Footnotes
 
 gmnhg supports footnotes, written like this[^1]. Footnotes can use any references, including alphanumeric ones[^2]; alphanumeric references will be replaced with numeric IDs on render.

--- a/testdata/links.gmi
+++ b/testdata/links.gmi
@@ -26,9 +26,10 @@ Other container elements can contain inline links as well. For instance, this is
 
 => https://xmpp.org/extensions/xep-0384.html XEP-0384
 
-Links will get encoded according to RFC 3986, like this sample link to nowhere.
+Links will get encoded according to RFC 3986, like this sample link to nowhere. The other sample link to somewhere on GitHub will not get transformed: sample.
 
 => /URI%20with%20spaces link
+=> https://github.com:443/request+with+characters%20 sample
 
 ## Footnotes
 

--- a/testdata/links.md
+++ b/testdata/links.md
@@ -33,7 +33,10 @@ this is an example of a link inside a blockquote:
 > — [XEP-0384](https://xmpp.org/extensions/xep-0384.html)
 
 Links will get encoded according to RFC 3986, like this sample
-[link](/URI with spaces) to nowhere.
+[link](/URI with spaces) to nowhere. The other sample link to
+somewhere on GitHub will not get transformed: [sample][elsewhere].
+
+[elsewhere]: https://github.com:443/request+with+characters%20
 
 ## Footnotes
 

--- a/testdata/links.md
+++ b/testdata/links.md
@@ -32,6 +32,9 @@ this is an example of a link inside a blockquote:
 > OTR has significant usability drawbacks for inter-client mobility.
 > — [XEP-0384](https://xmpp.org/extensions/xep-0384.html)
 
+Links will get encoded according to RFC 3986, like this sample
+[link](/URI with spaces) to nowhere.
+
 ## Footnotes
 
 gmnhg supports footnotes, written like this[^1]. Footnotes can use any


### PR DESCRIPTION
This makes gmnhg encode link destinations before rendering them into Gemtext according to RFC 3986. This fixes spaces in links in particular.

Fixes #49.

Introduces two new questions:

* whether or not gmnhg should skip invalid URIs (in the initial version of this PR, it does);
* whether or not all URIs must be encoded.